### PR TITLE
Bug Fix: Fixed bugs that prevent project from running on localhost

### DIFF
--- a/main.go
+++ b/main.go
@@ -168,7 +168,7 @@ func main() {
 
 func CORSMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		c.Writer.Header().Set("Access-Control-Allow-Origin", "https://jobs-scraper-production.up.railway.app/")
+		c.Writer.Header().Set("Access-Control-Allow-Origin", c.Request.Host)
 		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
 		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With")
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS, GET, PUT")

--- a/static/base.html
+++ b/static/base.html
@@ -325,7 +325,7 @@
 
         async function fetchAndDisplayJobs() {
             try {
-                const response = await fetch('https://jobs-scraper-production.up.railway.app/getallJobsFromSQL');
+                const response = await fetch(`${window.location.href}getallJobsFromSQL`);
         
                 if (!response.ok) {
                     throw new Error('Network response was not ok');


### PR DESCRIPTION
Bug Description: The `static/base.html` calls endpoint getallJobsFromSQL from https://jobs-scraper-production.up.railway.app/ instead of the local server. The browser blocks this request with a Unallowed CORS error. This prevents the app from being deployed on localhost or any other anywhere else.

Fix:
1.Updated the `static/base.html` to send requests from current host's URL
2.Updated the main.go file so that `Access-Control-Allow-Origin` value is set current host's URL