### PR TITLE
Fixed job card overflow

### DIFF
--- a/static/base.html
+++ b/static/base.html
@@ -41,6 +41,7 @@
             padding: 10px;
             position: sticky;
             top: 0;
+            z-index: 1;
         }
 
         .navbar .logo {
@@ -148,28 +149,12 @@
             color: #0e0d0d !important;
         }
 
-        .career-card {
-            width: 30rem;
-            margin-bottom: 20px;
-            background: linear-gradient(to bottom, #ffffff, #f0f0f0);
-            margin: 10px;
-             padding: 15px;
-            border: 2px solid #73AD21;
-            box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
-            text-align: left;
-            display: inline-block;
-            vertical-align: top;
-            border-radius: 8px;
-            background-color: #fff;
-            transition: transform 0.2s, box-shadow 0.2s;
-            
-        }
         .career-card h5.card-title {
              font-size: 18px;
              line-height: 1.4;
              font-weight: bold;
         }
-
+        
         .career-card p.card-text {
             font-size: 14px;
             line-height: 1.4;


### PR DESCRIPTION

I have added `z-index` to fix the bug. and I removed unuse `career-card` class CSS because this class has been implemented two times in code.

previous:

![image](https://github.com/Pavel401/Jobs-Scraper/assets/69814563/fad86c4f-46d1-4fb4-b42a-570bc1cbc8e3)

After:

![image](https://github.com/Pavel401/Jobs-Scraper/assets/69814563/4cb55a5f-1337-4d1e-aa2e-b02fe729a587)
